### PR TITLE
Link to Coq website in the description.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # Awesome Coq [![Awesome](https://cdn.rawgit.com/sindresorhus/awesome/d7305f38d29fed78fa85652e3a63e154dd8e8829/media/badge.svg)](https://github.com/sindresorhus/awesome)
 
-[<img src="coq-logo.svg" align="right" width="100">](https://coq.inria.fr)
+[<img src="coq-logo.svg" align="right" width="100" title="awesome-coq is a coq-community project">](https://github.com/coq-community/manifesto)
 
 > A curated list of awesome Coq libraries, plugins, tools, and resources.
 
-The Coq proof assistant provides a formal language to write mathematical definitions, executable algorithms, and theorems, together with an environment for semi-interactive development of machine-checked proofs.
+The [Coq proof assistant](https://coq.inria.fr) provides a formal language to write mathematical definitions, executable algorithms, and theorems, together with an environment for semi-interactive development of machine-checked proofs.
 
 ## Contents
 


### PR DESCRIPTION
To reduce confusion regarding what the logo represents, we link to the official Coq website from the text description rather than from the logo. Furthermore, we add a title to the logo (displayed on hover) to explain the connection (awesome-coq is a coq-community project).

The choice to make the logo a link to the manifesto is because images will be always clickable on GitHub, even if it is to the image source only.