### PR TITLE
Add CertiGraph to Libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Contributions welcome! Read the [contribution guidelines](https://github.com/coq
 - [Algebra Tactics](https://github.com/math-comp/algebra-tactics) - Ring and field tactics for Mathematical Components.
 - [Bignums](https://github.com/coq/bignums) - Library of arbitrarily large numbers.
 - [Bedrock Bit Vectors](https://github.com/mit-plv/bbv) - Library for reasoning on fixed precision machine words.
+- [CertiGraph](https://github.com/Salamari/CertiGraph) - Library for reasoning about directed graphs and their embedding in separation logic.
 - [CoLoR](https://github.com/fblanqui/color) - Library on rewriting theory, lambda-calculus and termination, with sub-libraries on common data structures extending the Coq standard library.
 - [coq-haskell](https://github.com/jwiegley/coq-haskell) - Library smoothing the transition to Coq for Haskell users.
 - [CoqInterval](https://gitlab.inria.fr/coqinterval/interval/) - Tactics for performing proofs of inequalities on expressions of real numbers.


### PR DESCRIPTION
CertiGraph is a library for reasoning about directed graphs and their embeddings in separation logic.  It has been used in two published papers in which graph algorithms are proved correct:  generational garbage collection, Dijkstra's shortest path, et cetera (see the README.md of the CertiGraph repo).

This pull-request is not self-promotion, since I am not an author of the repository or of those papers.  At most I have contributed to the packaging up of the library for release.  I did that because CertiGraph is useful to my own projects and I think it will be useful to others.

In fact, it is both
(c) absolutely unique in its approach and function, and 
(d) a niche product that fills a gap

CertiGraph is designed in a modular way so that it could fit on top of any separation logic.  Right now there is a VST binding for CertiGraph, but an Iris binding should be possible.