### PR TITLE
Add deployment to GitHub Pages

### DIFF
--- a/index.md
+++ b/index.md
@@ -1,0 +1,1 @@
+README.md


### PR DESCRIPTION
* Close https://github.com/coq-community/awesome-coq/issues/29

Replying to Karl's and Anton's question:

@palmskog 
> @erikmd I added the `project-awesome.org` link in the "About" part of the repo (i.e., not in the repo content). Is that what you had in mind? I don't think we want to have any link like that in the repo content.

Yes exactly, this is what I had in mind. Just editing the `About` section of the GitHub repo.

@anton-trunov 
> @erikmd Great idea! Btw, the first link shows me lots of ads -- I'm wondering if there is an option without ads?

Indeed, that's a concern; actually I had not spotted this because of / thanks to my Ad blocker 😅

So I believe this ad contents is not an acceptable feature for the "official" deployment of awesome-coq.

However I have another idea to suggest: just add a symbolic link `index.md → README.md` (cf. this PR), and enable the GitHub Pages feature for **branch** `master`, **directory** `/`.

Proof-of-concept: after pushing a similar commit to my fork and setting these options like the screenshot below, we get this:
https://erikmd.github.io/awesome-coq/

WDYT?

<details><summary><b>Screenshot</b></summary>

![2022-02-11_10-33-30_Screenshot_GitHub_Pages](https://user-images.githubusercontent.com/10367254/153569140-8a047b6f-da8b-4d6f-9232-a1d1db21b0d7.png)

</details>

The URL of the upstream deployment would thus be `https://coq-community.github.io/awesome-coq/`